### PR TITLE
Fix running on GNOME 3.36

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -17,7 +17,7 @@ function enable() {
         if (!this._source.app.is_window_backed()) {
             if (Shell.AppSystem.get_default().lookup_app('io.elementary.appcenter.desktop')) {
                 this._appendSeparator();
-                let item = this._appendMenuItem("Show Details");
+                let item = this._appendMenuItem(_("Show Details"));
                 item.connect('activate', () => {
                     let id = this._source.app.get_id();
                     Util.trySpawn(["io.elementary.appcenter", "appstream://" + id]);

--- a/extension.js
+++ b/extension.js
@@ -3,14 +3,15 @@ const Main = imports.ui.main;
 const Shell = imports.gi.Shell;
 const Util = imports.misc.util;
 
+let displayFunc = !!AppDisplay.AppIconMenu.prototype._rebuildMenu ? '_rebuildMenu' : '_redisplay';
 let old;
 
 function init() {}
 
 function enable() {
-    old = AppDisplay.AppIconMenu.prototype._redisplay;
+    old = AppDisplay.AppIconMenu.prototype[displayFunc];
 
-    AppDisplay.AppIconMenu.prototype._redisplay = function() {
+    AppDisplay.AppIconMenu.prototype[displayFunc] = function() {
         let ret = old.apply(this, arguments);
 
         if (!this._source.app.is_window_backed()) {
@@ -30,5 +31,5 @@ function enable() {
 }
 
 function disable() {
-    AppDisplay.AppIconMenu.prototype._redisplay = old;
+    AppDisplay.AppIconMenu.prototype[displayFunc] = old;
 }

--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,4 @@
 const AppDisplay = imports.ui.appDisplay;
-const Lang = imports.lang;
 const Main = imports.ui.main;
 const Shell = imports.gi.Shell;
 const Util = imports.misc.util;
@@ -18,11 +17,11 @@ function enable() {
             if (Shell.AppSystem.get_default().lookup_app('io.elementary.appcenter.desktop')) {
                 this._appendSeparator();
                 let item = this._appendMenuItem("Show Details");
-                item.connect('activate', Lang.bind(this, function() {
+                item.connect('activate', () => {
                     let id = this._source.app.get_id();
                     Util.trySpawn(["io.elementary.appcenter", "appstream://" + id]);
                     Main.overview.hide();
-                }));
+                });
             }
         }
 

--- a/metadata.json
+++ b/metadata.json
@@ -2,5 +2,6 @@
     "name": "Pop Shop Details",
     "description": "Adds a Show Details item to applications if Pop Shop is installed",
     "uuid": "pop-shop-details@system76.com",
-    "shell-version": ["3.26.1"]
+    "shell-version": ["3.26.1"],
+    "url": "https://github.com/pop-os/gnome-shell-extension-pop-shop-details"
 }


### PR DESCRIPTION
The `_redisplay()` function was renamed to `_rebuildMenu()` in GNOME 3.36.

Resolves: pop-os/beta#20
Resolves: #4 